### PR TITLE
退会の論理削除化ok #38

### DIFF
--- a/t0016Go/internal/types/types.go
+++ b/t0016Go/internal/types/types.go
@@ -91,8 +91,9 @@ type Listener struct {
 	Email        string
 	Password     string
 	CreatedAt    time.Time
-	UpdatedAt    sql.NullTime //new time.Timeのままで良かったかも
-	DeletedAt    sql.NullTime //new
+	UpdatedAt    sql.NullTime   //new time.Timeのままで良かったかも
+	DeletedAt    gorm.DeletedAt `gorm:"index"` //new
+	// DeletedAt    sql.NullTime //new これだと物理削除になってまう
 }
 
 type EntryListener struct {

--- a/t0016Go/internal/utility/auth.go
+++ b/t0016Go/internal/utility/auth.go
@@ -297,6 +297,32 @@ func LogoutHandler(c *gin.Context) {
 }
 
 // 退会 論理削除。その期限後削除、途中復活はまだ記述してない。
+// ******稼働確認したら物理削除になった********
+// func Withdrawal(c *gin.Context) {
+// 	tokenLId, err := TakeListenerIdFromJWT(c)
+// 	fmt.Printf("tokenLId = %v \n", tokenLId)
+// 	if err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{
+// 			"message": "Invalid ListenerId of token",
+// 			"err":     err,
+// 		})
+// 		return
+// 	}
+// 	var dummyLi types.Listener
+// 	result := Db.Model(&dummyLi).Where("Listener_id = ? ", tokenLId).Delete(dummyLi)
+// 	if result.Error != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{
+// 			"message": "Invalid Withdrawn",
+// 			"err":     result.Error,
+// 		})
+// 		return
+// 	}
+// 	c.SetCookie("auth-token", "none", -1, "/", "localhost", false, true)
+
+// 	c.JSON(http.StatusOK, gin.H{
+// 		"message": "Successfully Withdrawn",
+// 	})
+// }
 func Withdrawal(c *gin.Context) {
 	tokenLId, err := TakeListenerIdFromJWT(c)
 	fmt.Printf("tokenLId = %v \n", tokenLId)
@@ -308,7 +334,8 @@ func Withdrawal(c *gin.Context) {
 		return
 	}
 	var dummyLi types.Listener
-	result := Db.Model(&dummyLi).Where("Listener_id = ? ", tokenLId).Delete(dummyLi)
+	dummyLi.ListenerId = tokenLId
+	result := Db.Delete(&dummyLi)
 	if result.Error != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message": "Invalid Withdrawn",
@@ -317,7 +344,6 @@ func Withdrawal(c *gin.Context) {
 		return
 	}
 	c.SetCookie("auth-token", "none", -1, "/", "localhost", false, true)
-
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Successfully Withdrawn",
 	})

--- a/t0016Next/myapp/src/components/authButton.tsx
+++ b/t0016Next/myapp/src/components/authButton.tsx
@@ -58,20 +58,21 @@ export const Withdraw = () => {
   };
   return(
     <div>
-      {!isToDecision && <div>
+      {!isToDecision &&
+      <div>
         <button onClick={()=> setIsTpoDecision(!isToDecision)} >
-     退会手続きへ</button>
-     </div>}
-     {isToDecision}
+          退会手続きへ</button>
+      </div>}
      {isToDecision && <div> <br/>
-    <button onClick={fetchLogout}>！！！退会確定！！！</button>
-  <h2>退会について</h2>
-  <li>あなたのメールアドレス、パスワードが本サイトから削除されます。</li>
-  <li>それらは一時的に保管されますが、３０日後に機械的に自動で完全にされます。</li>
-  <li>あなたが登録したVTuber, Movie, Sing等のデータは削除されません。</li>
-  <button onClick={()=> setIsTpoDecision(!isToDecision)} >
-     キャンセル</button>
-   </div>}</div>
+      <button onClick={()=> setIsTpoDecision(!isToDecision)} >
+         キャンセル</button>
+      <h2>退会について</h2>
+        <li>あなたのメールアドレス、パスワードが本サイトから削除されます。</li>
+        <li>それらは一時的に保管されますが、３０日後に機械的に自動で完全にされます。</li>
+        <li>あなたが登録したVTuber, Movie, Sing等のデータは削除されません。</li>
+      <button onClick={fetchLogout}>！！！退会確定！！！</button>
+      </div>}
+    </div>
     )
 };
 


### PR DESCRIPTION
・論理削除化ok
　GoのDeletedAtの型をgorm.delete_atにしていなかったこと、
　delete.(hoge)でポインタを渡していなかった(delete(&hoge))こと
　の2点が原因だったと思われる。
なお、物理削除は未実装 ver1.5で実装予定